### PR TITLE
Got rid of the pop up message and added "Exculsions" logic

### DIFF
--- a/hook_system/client/ClientServer/scrubbing/scrub.py
+++ b/hook_system/client/ClientServer/scrubbing/scrub.py
@@ -87,7 +87,7 @@ for section in listdir(folder):
                 unScrubbedFolders = "\t" + studentSubmission + "\n"
                 numOfUnscrubbedFolders = numOfUnscrubbedFolders + 1
 
-#if any folder causes an exception, then show an alert at the end with the summary
+#if any folder causes an exception, send a sys.exit error message
 if numOfUnscrubbedFolders == 1:
     alertMessage = "A submission was not able to be scrubbed. It is listed below:\n"
     alertMessage = alertMessage + unScrubbedFolders


### PR DESCRIPTION
There is no more pop up message. Now the same message that was on the pop up will be returned in a sys.exit -- is this good or do you just want a number?
Also added the code to copy all the files (whether in sub-directories or not) from the Exclusions file to the Exculsions file in the Scrubbed Folder that will be sent to the processing server. Note: in the scrubbed folder that will be sent to the processing server all the files will be under "Exclusions" - aka no sub-directories.