### PR TITLE
Changing psycopg2 requirement to address server errors

### DIFF
--- a/hook_system/processor/requirements.txt
+++ b/hook_system/processor/requirements.txt
@@ -18,7 +18,7 @@ lazy-object-proxy==1.3.1
 MarkupSafe==1.1.0
 mccabe==0.6.1
 openapi-spec-validator==0.2.4
-psycopg2==2.7.7
+psycopg2-binary >= 2.7.4
 PyYAML==3.13
 requests==2.21.0
 six==1.12.0


### PR DESCRIPTION
This has already been updated on the server, just keeping things consistent upstream.