### PR TITLE
Add more accurate processing time for submissions

### DIFF
--- a/hook_system/processor/Src/apiRoutes.py
+++ b/hook_system/processor/Src/apiRoutes.py
@@ -38,6 +38,7 @@ def submit(userId: str, email: str, data) -> str:
     fileCount = 0
     java_files = 0
     cpp_files = 0
+    fileType = True  #default to True to give processing time for java files
     with tar.open(filename, mode='r') as tarFile:
         for fileName in tarFile.getnames():
             if tarFile.getmember(fileName).isfile():
@@ -77,9 +78,11 @@ def submit(userId: str, email: str, data) -> str:
     if java_files < 1 and cpp_files < 1:
         os.remove(filename)
         return {"JobId" : '', "EstimatedCompletion" : '', "Status": "Insufficient files to detect plagiarism"}, 400
+    if java_files < cpp_files:
+        fileType = False
 
     #Add the filename to a queue to process
-    added, waitTime = submissionQueue.addToQueue(filename,fileCount, email)
+    added, waitTime = submissionQueue.addToQueue(filename,fileCount,fileType, email)
     addJob(userId, jobID)
 
     if added:
@@ -111,9 +114,9 @@ def fetch(userId: str, jobId: str) -> str:
     xmlResults = ""
     with open(resultPath, 'r') as f:
         xmlResults = ''.join(f.readlines())
-
-    os.remove(resultPath)
-    removeJob(jobId)
+#    Remove these with a cronjob to extend the ability to download
+#    os.remove(resultPath)
+#    removeJob(jobId)
 
     return {'Results': xmlResults, 'Status': 'Ok', 'Wait':''}
 


### PR DESCRIPTION
I updated the values used to estimate processing for java files and c files and updated the estimating function to give a more accurate estimate based on the types of files that are predominant. 
I have also commented out the lines that delete results from the database and server storage immediately, to be replaced with a cronjob that deletes after 90+ days